### PR TITLE
RFC: do not redefine `def` macro and use attribute tags

### DIFF
--- a/lib/contracts.ex
+++ b/lib/contracts.ex
@@ -26,7 +26,7 @@ defmodule Contracts do
     end
   end
 
-  def on_definition(env, kind, name, args, guards, body) when kind in [:def, :defp] do
+  def __on_definition__(env, kind, name, args, guards, body) when kind in [:def, :defp] do
     mod = env.module
     precond  = Module.get_attribute(mod, :requires)
     postcond = Module.get_attribute(mod, :ensures)

--- a/lib/contracts.ex
+++ b/lib/contracts.ex
@@ -1,42 +1,99 @@
 defmodule Contracts do
-  @default %{pre: true, post: true}
+  defmodule Contract do
+    defstruct precondition: nil, postcondition: nil, func_name: nil, func_args: nil, func_guards: nil, func_body: nil
+  end
+
   defmacro __using__(_opts) do
-    {:ok, _} = Agent.start_link(fn -> @default end, name: __name__(__CALLER__))
     quote do
-      import Kernel, except: [def: 2]
       import Contracts
-      @before_compile unquote(__MODULE__)
+
+      Module.register_attribute(__MODULE__, :contract_predicates, accumulate: true, persist: true)
+
+      @before_compile Contracts
+      @on_definition  Contracts
     end
   end
 
   defmacro __before_compile__(env) do
-    :ok = Agent.stop(__name__(env))
+    mod = env.module
+    predicates = Module.get_attribute(mod, :contract_predicates) |> Enum.reverse
+
+    contract_funcs = predicates
+    |> Enum.map(&build_contract_function(&1, env))
+
+    quote do
+      unquote_splicing(contract_funcs)
+    end
   end
 
-  def __name__(env), do: Module.concat(__MODULE__, env.module)
+  def on_definition(env, kind, name, args, guards, body) when kind in [:def, :defp] do
+    mod = env.module
+    precond  = Module.get_attribute(mod, :requires)
+    postcond = Module.get_attribute(mod, :ensures)
 
-  defmacro requires(pre) do
-    Agent.update(__name__(__CALLER__), &%{&1 | pre: pre})
+    contract = %Contract{
+      func_name:   name,
+      func_args:   args,
+      func_guards: guards,
+      func_body:   body,
+    }
+
+    if precond do
+      contract = %{ contract | precondition: precond}
+      Module.delete_attribute(mod, :requires)
+    end
+    if postcond do
+      contract = %{ contract | postcondition: postcond}
+      Module.delete_attribute(mod, :ensures)
+    end
+
+    if precond || postcond do
+      Module.put_attribute(mod, :contract_predicates, contract)
+    end
+
+    :ok
   end
+  def __on_definition__(_env, _kind, _name, _args, _gaurds, _body), do: :ok
 
-  defmacro ensures(post) do
-    Agent.update(__name__(__CALLER__), &%{&1 | post: post})
-  end
+  defp build_contract_function(%Contract{}=contract, env) do
+    mod = env.module
+    Module.make_overridable(mod, [{contract.func_name, contract.func_args |> length}])
 
-  defmacro def(definition, do: content) do
-    %{pre: pre, post: post} = Agent.get(__name__(__CALLER__), &(&1))
+    body = quote do
+      unless unquote(contract.precondition), do: raise "Precondition not met: blame the client"
+      var!(result) = unquote(contract.func_body)
+      unless unquote(contract.postcondition), do: raise "Postcondition not met: blame yourself"
 
-    ast = quote do
-      Kernel.def(unquote(definition)) do
-        unless unquote(pre), do: raise "Precondition not met: blame the client"
-        var!(result) = unquote(content)
-        unless unquote(post), do: raise "Postcondition not met: blame yourself"
+      var!(result)
+    end
 
-        var!(result)
+    if contract.func_guards |> length > 0 do
+      quote do
+        def unquote(contract.func_name)(unquote_splicing(contract.func_args)) when unquote_splicing(contract.func_guards) do
+          unquote(body)
+        end
+      end
+
+    else
+      quote do
+        def unquote(contract.func_name)(unquote_splicing(contract.func_args)) do
+          unquote(body)
+        end
       end
     end
-    Agent.update(__name__(__CALLER__), fn _ -> @default end)
-
-    ast
   end
+
+  defmacro contract(predicate) do
+    Macro.escape(predicate)
+  end
+
+  # defmacro requires(predicate) do
+  #   mod = __CALLER__.module
+  #   Module.put_attribute(mod, :requires, predicate)
+  # end
+
+  # defmacro ensures(predicate) do
+  #   mod = __CALLER__.module
+  #   Module.put_attribute(mod, :ensures, predicate)
+  # end
 end

--- a/test/contracts_test.exs
+++ b/test/contracts_test.exs
@@ -6,14 +6,14 @@ defmodule ContractsTest do
 
     use Contracts
 
-    requires not full?(tank) && tank.in_valve == :open && tank.out_valve == :closed
-    ensures full?(result) && result.in_valve == :closed && result.out_valve == :closed
+    @requires contract not full?(tank) && tank.in_valve == :open && tank.out_valve == :closed
+    @ensures  contract full?(result) && result.in_valve == :closed && result.out_valve == :closed
     def fill(tank) do
       %Tank{tank | level: 10, in_valve: :closed}
     end
 
-    requires tank.in_valve == :closed && tank.out_valve == :open
-    ensures empty?(result) && result.in_valve == :closed && result.out_valve == :closed
+    @requires contract tank.in_valve == :closed && tank.out_valve == :open
+    @ensures  contract empty?(result) && result.in_valve == :closed && result.out_valve == :closed
     def empty(tank) do
       %Tank{tank | level: 1, out_valve: :closed}
       # %Tank{tank | level: 0, out_valve: :closed}


### PR DESCRIPTION
I've made a mistake making the original pull request from master branch. I've created another pull request, #2, if you wan't to comment on it - this one I'm closing.

---

I've seen your talk yesterday - nice one! DbC is a great concept especial in Elixir/Erlang in creating fault tolerant systems.

This pull request is meant to be of a Request For Comment and initiating a discussion. My implementation, removes the need to redefine `def` macro (redefining core functions/macros is somewhat iffy and can have side effects, especial if another module does the same thing). Additionally, adding a contract to a functions feels more like it's a meta information about that function, so attributes are more appropriate way of assigning a contract to a function (tagging it with a contract).

By doing this that way, (in the future) we can extend this by adding another attribute for defining how to inform about a broken condition:

```
@requires contract tank.in_valve == :closed && tank.out_valve == :open
@ensures  contract empty?(result) && result.in_valve == :closed && result.out_valve == :closed
@on_break :error_tupel
def empty(tank) do
```

which will return a `{:error, result}`. Or maybe a information what part of contract was broken.

Unfortunately, since attributes require values, their arguments are evaluated first. This is why macro `contract` is needed, to return AST form of a conditions . It basically works as a `quote`, but this can change if we'll add more information when raising on broken conditions (maybe similar information to what is returned by `ExCase.assert` macro).

Pros:
- not redefining a core Elixir element - `def` macro
- tagging functions with contracts feels more correct than calling macros before a definition of a function
- introspection - `Module.info :attributes` returns `contract_predicates` attribute containing information about each tagged functions 

Cons:
- breaking changes (use of attributes instead of macros)
- need of `contract` macro

Also, I think we should use singular form `ensure` and `require`.

Cheers!
